### PR TITLE
Test to demo target reset in test

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,6 +19,6 @@
   "testDependencies": {
     "utest": "^1.10.0",
     "unity": "^2.0.1",
-    "mbed-drivers": "^1.0.0"
+    "minar": "^1.1.0"
   }
 }

--- a/module.json
+++ b/module.json
@@ -17,6 +17,8 @@
   "dependencies": {
   },
   "testDependencies": {
-    "utest": "^1.10.0"
+    "utest": "^1.10.0",
+    "unity": "^2.0.1",
+    "mbed-drivers": "^1.0.0"
   }
 }

--- a/test/host_tests/reset_test.py
+++ b/test/host_tests/reset_test.py
@@ -16,6 +16,25 @@ from mbed_host_tests import BaseHostTest, event_callback
 
 
 class ResetTest(BaseHostTest):
+    """
+    In this test target requests a reset by sending {{reset;}} key.
+    Host test manages target state before and after reset. On start
+    up host test sends initial state to the target using key:
+    {{state;<state>}}
+
+    In state==0 target starts an echo test. Target validates the echoes
+    to be same as the sent. Example: Sent {{echo;1}} should results in
+    receiving {{echo;1}}. In the end it changes state to 1 and
+    sends state to host test and requests reset.
+
+    Host test resets the target and target startup happens as before.
+    Host test sends stored state to the target. 
+
+    In state==1 target starts an echo test and expects echoes with
+    n x 2. Example: if echo is {{echo;1}} then response should be
+    {{echo;2}}. Target validates the echoes and finishes the test
+    after 10 echoes.
+    """
 
     def __init__(self):
         """

--- a/test/host_tests/reset_test.py
+++ b/test/host_tests/reset_test.py
@@ -1,0 +1,93 @@
+# Copyright 2015 ARM Limited, All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mbed_host_tests import BaseHostTest, event_callback
+
+
+class ResetTest(BaseHostTest):
+
+    def __init__(self):
+        """
+        Initialise test parameters.
+
+        :return:
+        """
+        super(BaseHostTest, self).__init__()
+        self.state = 0 # Default/start state until updated by the target
+
+    @event_callback("start")
+    def _callback_start(self, key, value, timestamp):
+        """
+        Key "start" handler to initiate the test.
+
+        :param key:
+        :param value:
+        :param timestamp:
+        :return:
+        """
+        # Tell stored state to the target
+        self.send_kv("state", self.state)
+
+    @event_callback("echo")
+    def _callback_echo(self, key, value, timestamp):
+        """
+        Key "echo" handler. Echoes back the received number after multiplying with
+        a state corresponding multiplier.
+
+        state   multiplier
+        0       1
+        1       2
+
+        :param key:
+        :param value:
+        :param timestamp:
+        :return:
+        """
+        assert self.state in [0, 1], "Unknown state!"
+        if self.state == 0:
+            multiplier = 1
+        elif self.state == 1:
+            multiplier = 2
+        self.send_kv("echo", multiplier * int(value))
+
+    @event_callback("state")
+    def _callback_state(self, key, value, timestamp):
+        """
+        Key "state" handler. Updateds the target state.
+
+        :param key:
+        :param value:
+        :param timestamp:
+        :return:
+        """
+        self.state = int(value)
+
+    @event_callback("reset")
+    def _callback_reset(self, key, value, timestamp):
+        """
+        Key "reset" handler. Resets the target and on come back reinitializes to last known state.
+
+        :param key:
+        :param value:
+        :param timestamp:
+        :return:
+        """
+        self.reset_dut()
+
+    def teardown(self):
+        """
+        Test tear down handler.
+        """
+        pass
+

--- a/test/reset/main.cpp
+++ b/test/reset/main.cpp
@@ -54,14 +54,12 @@ void do_echo_test(int response_multiplier)
 
     for (int i =0; i < 10; i++)
     {
-        snprintf(data, sizeof(data), "%d", i);
-        greentea_send_kv("echo", data);
+        greentea_send_kv("echo", i);
 
         TEST_ASSERT_NOT_EQUAL_MESSAGE(0, greentea_parse_kv(key, data, sizeof(key), sizeof(data)), "MBED: Failed to recv/parse key \"state\" value from host test!");
         TEST_ASSERT_EQUAL_STRING("echo", key);
 
-        uint8_t count;
-        sscanf(data, "%hhu", &count);
+        uint8_t count = atoi(data);
 
         TEST_ASSERT_EQUAL_MESSAGE(i * response_multiplier, count, "MBED: Failed to verify count received in echo!");
     }
@@ -92,8 +90,7 @@ void reset_test_cb()
     char data[] = "10";
     TEST_ASSERT_NOT_EQUAL_MESSAGE(0, greentea_parse_kv(key, data, sizeof(key), sizeof(data)), "MBED: Failed to recv/parse key \"state\" value from host test!");
 
-    uint8_t state;
-    sscanf(data, "%hhu", &state);
+    uint8_t state = atoi(data);
     
     TEST_ASSERT_TRUE(state <= 1);
 

--- a/test/reset/main.cpp
+++ b/test/reset/main.cpp
@@ -1,0 +1,151 @@
+/*
+ * PackageLicenseDeclared: Apache-2.0
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @file main.cpp
+ *
+ * This test suite tests scenarios to reset target in-between the test.
+ *
+ *   The following tests are implemented in this file:
+ *     Test 1            Reset target inbetween the tests.
+ */
+
+#include "greentea-client/test_env.h"
+#include "utest/utest.h"
+#include "unity/unity.h"
+
+#include "mbed-drivers/mbed.h"
+
+#include <algorithm>
+#include <cstdlib>
+
+using namespace utest::v1;
+
+/** Custom echo test
+ * 
+ *  This function sends key,value pairs like {{echo;n}}. Where n is a number.
+ *  Host replies back with {{echo;m*n}}. Where m is a multiplier both target
+ *  and host know based on the target state.
+ *
+ *        state     multiplier
+ *          0           1
+ *          1           2
+ *
+ *  Response is asserted to verify the state based execution of both host
+ *  and target before and after reset.
+ */
+void do_echo_test(int response_multiplier)
+{
+    char key[] = "echo";
+    char data[] = "10";
+
+    for (int i =0; i < 10; i++)
+    {
+        snprintf(data, sizeof(data), "%d", i);
+        greentea_send_kv("echo", data);
+
+        TEST_ASSERT_NOT_EQUAL_MESSAGE(0, greentea_parse_kv(key, data, sizeof(key), sizeof(data)), "MBED: Failed to recv/parse key \"state\" value from host test!");
+        TEST_ASSERT_EQUAL_STRING("echo", key);
+
+        uint8_t count;
+        sscanf(data, "%hhu", &count);
+
+        TEST_ASSERT_EQUAL_MESSAGE(i * response_multiplier, count, "MBED: Failed to verify count received in echo!");
+    }
+}
+
+
+/** Reset test
+ * 
+ *  This function executes the reset test. It kicks off the host test by sedning
+ *  {{start;}}
+ *  Then receives state from host {{state;x}}. Where it should be x=0 on first start and 1
+ *  after reset.
+ *  In both before and after iterations it runs an echo test. It verifies the echoes based
+ *  on a multiplier known to both target and host test code based on the target state.
+ *
+ *        state     multiplier
+ *          0           1
+ *          1           2
+ *
+ */
+void reset_test_cb()
+{
+    // Start the test
+    greentea_send_kv("start", " ");
+
+    // A startup read state from the host
+    char key[] = "state";
+    char data[] = "10";
+    TEST_ASSERT_NOT_EQUAL_MESSAGE(0, greentea_parse_kv(key, data, sizeof(key), sizeof(data)), "MBED: Failed to recv/parse key \"state\" value from host test!");
+
+    uint8_t state;
+    sscanf(data, "%hhu", &state);
+    
+    TEST_ASSERT_TRUE(state <= 1);
+
+    // Start echo test with a response multiplier that is shared secret between target and host to demonstrated
+    // state correspondance. 
+    // state   multiplier
+    //   0        1
+    //   1        2
+
+    if (state == 0)
+    {
+        do_echo_test(1);
+
+        // change state to 1 and reset.
+        greentea_send_kv("state", "1");
+        greentea_send_kv("reset", " ");
+    }
+    else if (state == 1)
+    {
+        do_echo_test(2);
+        Harness::validate_callback();
+    }
+
+}
+
+control_t reset_test(const size_t)
+{
+    minar::Scheduler::postCallback(reset_test_cb).delay(minar::milliseconds(100));
+    return CaseAwait;
+}
+
+
+
+const Case cases[] =
+{
+    Case("Reset Test", reset_test),
+};
+
+void greentea_teardown(const size_t passed, const size_t failed, const failure_t failure)
+{
+    greentea_test_teardown_handler(passed, failed, failure);
+}
+
+status_t greentea_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(60, "reset_test");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+const Specification specification(greentea_setup, cases, greentea_teardown);
+
+void app_start(int, char **) {
+    Harness::run(specification);
+}
+

--- a/test/reset/main.cpp
+++ b/test/reset/main.cpp
@@ -27,10 +27,7 @@
 #include "utest/utest.h"
 #include "unity/unity.h"
 
-#include "mbed-drivers/mbed.h"
-
-#include <algorithm>
-#include <cstdlib>
+#include "minar/minar.h"
 
 using namespace utest::v1;
 


### PR DESCRIPTION
Test to demo DUT reset in a test and manage test state.

This test kicks off the host test by sending {{start;}}
Then receives state from host as {{state;x}}. Where it should be x=0 on first start and 1
after reset.
At the end of first iteration it asks host test to reset the target.
In both before and after iterations it runs an echo test. It verifies the echoes based
on a multiplier known to both target and host test code based on the target state.

```
    state     multiplier
      0           1
      1           2
```
