### PR TITLE
Updated reset test with hardware reset

### DIFF
--- a/test/host_tests/reset_test.py
+++ b/test/host_tests/reset_test.py
@@ -102,7 +102,7 @@ class ResetTest(BaseHostTest):
         :param timestamp:
         :return:
         """
-        self.reset_dut()
+        self.reset_dut(value)
 
     def teardown(self):
         """

--- a/test/reset/main.cpp
+++ b/test/reset/main.cpp
@@ -103,7 +103,7 @@ void reset_test_cb()
 
         // change state to 1 and reset.
         greentea_send_kv("state", "1");
-        greentea_send_kv("reset", " ");
+        greentea_send_kv("reset", "hardware_reset");
     }
     else if (state == 1)
     {


### PR DESCRIPTION
Updated the test to perform a hardware reset in between the test. This PR depends on PR https://github.com/ARMmbed/htrun/pull/77. See documentation in the related PR for feature details.
