### PR TITLE
Add an empty implementation for greentea_metrics

### DIFF
--- a/source/greentea_metrics.cpp
+++ b/source/greentea_metrics.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "greentea-client/greentea_metrics.h"
+
+void greentea_metrics_setup()
+{
+}
+
+void greentea_metrics_report()
+{
+}

--- a/source/greentea_test_env.cpp
+++ b/source/greentea_test_env.cpp
@@ -20,7 +20,6 @@
 #include <string.h>
 #include "greentea-client/test_env.h"
 #include "greentea-client/greentea_metrics.h"
-#include "mbed_trace.h"
 #include "platform/mbed_retarget.h"
 
 /**
@@ -81,10 +80,6 @@ void _GREENTEA_SETUP_COMMON(const int timeout, const char *host_test_name, char 
             break;
         }
     }
-
-#ifdef MBED_CONF_MBED_TRACE_ENABLE
-    mbed_trace_init();
-#endif
 
     greentea_notify_version();
     greentea_notify_timeout(timeout);


### PR DESCRIPTION
We plan to remove the dependency on the metrics reporting fixture, but until then add an empty implementation so greentea-client is usable outside of Mbed.

Also remove the dependency on mbed_trace as we initialise it but don't seem to use it anywhere.

Based on #19 