### PR TITLE
Add support for stdio, CMake and example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.10)
+
+project(greentea-client
+    VERSION 0.1
+    DESCRIPTION "Greentea client"
+    LANGUAGES C CXX
+)
+
+add_library(greentea-client)
+
+target_include_directories(greentea-client
+    PUBLIC
+        include
+)
+
+target_sources(greentea-client
+    PRIVATE
+        source/greentea_test_env.cpp
+)
+
+# Default IO
+
+SET(GREENTEA_CLIENT_STDIO ON CACHE BOOL "Use stdio for IO")
+
+if(GREENTEA_CLIENT_STDIO)
+    target_sources(greentea-client
+        PRIVATE
+            source/greentea_test_io.c
+    )
+endif()
+
+# Metrics
+
+SET(GREENTEA_CLIENT_DUMMY_METRICS ON CACHE BOOL "Use dummy no-op implementation of metrics")
+
+if(GREENTEA_CLIENT_DUMMY_METRICS)
+    target_sources(greentea-client
+        PRIVATE
+            source/greentea_metrics.cpp
+    )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,3 +42,7 @@ if(GREENTEA_CLIENT_DUMMY_METRICS)
             source/greentea_metrics.cpp
     )
 endif()
+
+# Example application
+
+add_subdirectory(example)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_executable(greentea-client-example main.cpp)
+
+target_link_libraries(greentea-client-example
+        greentea-client
+)

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "greentea-client/test_env.h"
+
+int main()
+{
+    const char *key = "demo_key";
+    const int value = 60;
+    greentea_send_kv(key, value);
+
+    return 0;
+}

--- a/include/greentea-client/test_env.h
+++ b/include/greentea-client/test_env.h
@@ -1,8 +1,5 @@
-
-/** \addtogroup frameworks */
-/** @{*/
 /*
- * Copyright (c) 2013-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2013-2021, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -21,10 +18,11 @@
 #ifndef GREENTEA_CLIENT_TEST_ENV_H_
 #define GREENTEA_CLIENT_TEST_ENV_H_
 
+#include <stddef.h>
+#include "greentea-client/test_io.h"
+
 #ifdef __cplusplus
 #define MBED_GREENTEA_CLIENT_VERSION_STRING "1.3.0"
-
-#include <stdio.h>
 
 /**
  *  Auxilary macros
@@ -116,14 +114,9 @@ void GREENTEA_SETUP(const int timeout, const char *host_test);
 void greentea_send_kv(const char *key, const char *val);
 int greentea_parse_kv(char *key, char *val,
                       const int key_len, const int val_len);
-int greentea_getc();
-void greentea_putc(int c);
-void greentea_write_string(const char *str);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif  // GREENTEA_CLIENT_TEST_ENV_H_
-
-/** @}*/

--- a/include/greentea-client/test_io.h
+++ b/include/greentea-client/test_io.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GREENTEA_CLIENT_TEST_IO_H_
+#define GREENTEA_CLIENT_TEST_IO_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ *  Greentea-client IO
+ */
+
+/**
+ * Read character from stream of data.
+ *
+ * @return Next character from the stream or EOF if stream has ended.
+ */
+int greentea_getc();
+
+/**
+ * Write character to stream of data.
+ *
+ * @return The number of bytes written.
+ */
+void greentea_putc(int c);
+
+/**
+ * Write string to stream of data.
+ *
+ * @param str String value.
+ */
+void greentea_write_string(const char *str);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // GREENTEA_CLIENT_TEST_IO_H_

--- a/source/greentea_test_env.cpp
+++ b/source/greentea_test_env.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2013-2021, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 
-#include <ctype.h>
+#include <cctype>
 #include <cstdio>
-#include <string.h>
+#include <cstring>
 #include "greentea-client/test_env.h"
 #include "greentea-client/greentea_metrics.h"
-#include "platform/mbed_retarget.h"
 
 /**
  *   Generic test suite transport protocol keys
@@ -241,22 +240,6 @@ static void greentea_write_postamble()
     greentea_putc('\r');
     greentea_putc('\n');
 }
-
-/**
- * \brief Write a string to the serial port
- *
- *        This function writes a '\0' terminated string from the target
- *        to the host. It writes directly to the serial port using the
- *        the write() method.
- *
- * \param str - string value
- *
- */
-void greentea_write_string(const char *str)
-{
-    write(STDOUT_FILENO, str, strlen(str));
-}
-
 
 /**
  * \brief Write an int to the serial port
@@ -547,42 +530,6 @@ enum Token {
     tok_semicolon = -4,
     tok_string = -5
 };
-
-/**
- * \brief Read character from stream of data
- *
- *        Closure for default "get character" function.
- *        This function is used to read characters from the stream
- *        (default is serial port RX). Key-value protocol tokenizer
- *        will build stream of tokes used by key-value protocol to
- *        detect valid messages.
- *
- *        If EOF is received parser finishes parsing and stops. In
- *        situation where we have serial port stream of data parsing
- *        goes forever.
- *
- * \return Next character from the stream or EOF if stream has ended.
- *
- */
-extern "C" int greentea_getc()
-{
-    uint8_t c;
-    read(STDOUT_FILENO, &c, 1);
-    return c;
-}
-
-
-/**
- * \brief Write character from stream of data
- *
- * \return The number of bytes written
- *
- */
-extern "C" void greentea_putc(int c)
-{
-    uint8_t _c = c;
-    write(STDOUT_FILENO, &_c, 1);
-}
 
 /**
  * \brief parse input string for key-value pairs: {{key;value}}

--- a/source/greentea_test_io.c
+++ b/source/greentea_test_io.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2013-2021, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "greentea-client/test_io.h"
+#include <stdio.h>
+
+int greentea_getc() {
+    return getchar();
+}
+
+
+void greentea_putc(int c) {
+    putchar(c);
+}
+
+
+void greentea_write_string(const char *str)
+{
+    puts(str);
+}


### PR DESCRIPTION
Preceding PRs: #19, #20

This PR (see the last three commits)
* adds an implementation of Greentea IO based on stdio
* adds CMakeLists.txt
* adds an example application

To build the example application:
```
cmake -S example/ -B cmake_build -GNinja
cmake --build cmake_build
```
The generated `./cmake_build/greentea-client-example` is executable on the PC that builds it.