### PR TITLE
example: Build examples if the main project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,4 +34,8 @@ endif()
 
 # Example application
 
-add_subdirectory(example)
+set(BUILD_EXAMPLES ON CACHE BOOL "Enable building the examples")
+
+if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME) AND BUILD_EXAMPLES)
+    add_subdirectory(example)
+endif()


### PR DESCRIPTION
Only build examples if this project is the main project. When used as a
subproject of another, examples aren't very useful to spend time
building.