### PR TITLE
Export CMake targets

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -35,3 +35,14 @@ jobs:
       run: |
         cmake -S . -B __build -GNinja -DGREENTEA_CLIENT_STDIO=OFF
         cmake --build __build
+
+    - name: Install greentea-client
+      run: |
+        cmake -S . -B __build -GNinja -DGREENTEA_CLIENT_STDIO=ON
+        cmake --build __build
+        sudo cmake --install __build
+
+    - name: Test downstream application can use find_package
+      run: |
+        cmake -S tests/integration/imported-targets -B __downstream_build -GNinja
+        cmake --build __downstream_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,22 +3,76 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-project(greentea-client
+project(greentea
     VERSION 0.1
     DESCRIPTION "Greentea client"
     LANGUAGES C CXX
 )
 
-add_library(greentea-client)
+include(GNUInstallDirs)
 
-target_include_directories(greentea-client
+add_library(client)
+target_include_directories(client
     PUBLIC
-        include
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-target_sources(greentea-client
+target_sources(client
     PRIVATE
         source/greentea_test_env.cpp
+)
+
+# Consumers using add_subdirectory should link to this target. This alias keeps
+# the naming consistent between superprojects that include greentea-client in
+# the source tree and projects that use the installed greentea-client library
+# using find_package.
+add_library(greentea::client ALIAS client)
+
+# Exported targets
+
+install(
+    TARGETS client
+    EXPORT greentea-client-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(DIRECTORY include/greentea-client DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(
+    EXPORT greentea-client-targets
+    FILE greentea-client-targets.cmake
+    NAMESPACE greentea::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/greentea
+)
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/greenteaConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/greentea
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/greenteaConfigVersion.cmake"
+    VERSION "${PROJECT_VERSION}"
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/greenteaConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/greenteaConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/greentea
+)
+
+export(
+    EXPORT greentea-client-targets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/greentea-client-targets.cmake"
+    NAMESPACE greentea::
 )
 
 # Default IO
@@ -26,7 +80,7 @@ target_sources(greentea-client
 SET(GREENTEA_CLIENT_STDIO ON CACHE BOOL "Use stdio for IO")
 
 if(GREENTEA_CLIENT_STDIO)
-    target_sources(greentea-client
+    target_sources(client
         PRIVATE
             source/greentea_test_io.c
     )

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/greentea-client-targets.cmake")
+
+check_required_components(client)

--- a/examples/custom_io/CMakeLists.txt
+++ b/examples/custom_io/CMakeLists.txt
@@ -4,5 +4,5 @@
 add_executable(greentea-client-example main.cpp)
 
 target_link_libraries(greentea-client-example
-        greentea-client
+        greentea::client
 )

--- a/examples/stdio/CMakeLists.txt
+++ b/examples/stdio/CMakeLists.txt
@@ -4,5 +4,5 @@
 add_executable(greentea-client-example main.cpp)
 
 target_link_libraries(greentea-client-example
-        greentea-client
+        greentea::client
 )

--- a/tests/integration/imported-targets/CMakeLists.txt
+++ b/tests/integration/imported-targets/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.10)
+
+project(imported-targets
+    VERSION 0.1
+    DESCRIPTION "Tests greentea-client's exported targets can be imported"
+    LANGUAGES C CXX
+)
+
+find_package(greentea REQUIRED)
+
+add_executable(imported-targets main.cpp)
+target_link_libraries(imported-targets greentea::client)

--- a/tests/integration/imported-targets/main.cpp
+++ b/tests/integration/imported-targets/main.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "greentea-client/test_env.h"
+
+int main()
+{
+    static const char *const key = "Hello";
+    static const char *const val = "99";
+    greentea_send_kv(key, val);
+
+    return 0;
+}


### PR DESCRIPTION
Exporting greentea-client CMake targets allows downstream projects to
discover and import the targets using find_package. After the targets
are imported users can reference them inside of their project. This
means that users won't be forced to vendor greentea-client if they
depend on it, they could instead install it to a known location where
CMake can look up the targets and import them.

This PR adds the code to export the greentea::client target and an
example application which uses find_package to import it. This 
example is added to the github CI workflow.