### PR TITLE
Obtain a version automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,15 @@
 
 cmake_minimum_required(VERSION 3.10)
 
+include(cmake/GitVersion.cmake)
+
+message("version ${GIT_VERSION}")
+message("major ${GIT_VERSION_MAJOR}")
+message("minor ${GIT_VERSION_MINOR}")
+message("patch ${GIT_VERSION_PATCH}")
+
 project(greentea-client
-    VERSION 0.1
+    VERSION ${GIT_VERSION_MAJOR}.${GIT_VERSION_MINOR}.${GIT_VERSION_PATCH}
     DESCRIPTION "Greentea client"
     LANGUAGES C CXX
 )
@@ -19,6 +26,11 @@ target_include_directories(greentea-client
 target_sources(greentea-client
     PRIVATE
         source/greentea_test_env.cpp
+)
+
+target_compile_definitions(greentea-client
+    PUBLIC
+        GIT_VERSION=${GIT_VERSION}
 )
 
 # Default IO

--- a/cmake/GitVersion.cmake
+++ b/cmake/GitVersion.cmake
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+execute_process(COMMAND git describe --tags --abbrev=12 --dirty --always
+                OUTPUT_VARIABLE GIT_VERSION
+                ERROR_QUIET)
+
+if (GIT_VERSION MATCHES "^v([0-9]+)\.([0-9]+)\.([0-9]+)")
+    set(GIT_VERSION_MAJOR ${CMAKE_MATCH_1})
+    set(GIT_VERSION_MINOR ${CMAKE_MATCH_2})
+    set(GIT_VERSION_PATCH ${CMAKE_MATCH_3})
+else()
+    set(GIT_VERSION_MAJOR 0)
+    set(GIT_VERSION_MINOR 0)
+    set(GIT_VERSION_PATCH 0)
+endif()

--- a/include/greentea-client/test_env.h
+++ b/include/greentea-client/test_env.h
@@ -22,7 +22,6 @@
 #include "greentea-client/test_io.h"
 
 #ifdef __cplusplus
-#define GREENTEA_CLIENT_VERSION_STRING "1.3.0"
 
 /**
  *  Auxilary macros

--- a/source/greentea_test_env.cpp
+++ b/source/greentea_test_env.cpp
@@ -476,7 +476,7 @@ static void greentea_notify_completion(const int result)
  */
 static void greentea_notify_version()
 {
-    greentea_send_kv(GREENTEA_TEST_ENV_HOST_TEST_VERSION, GREENTEA_CLIENT_VERSION_STRING);
+    greentea_send_kv(GREENTEA_TEST_ENV_HOST_TEST_VERSION, "1.3.0");
 }
 
 /**

--- a/source/greentea_test_env.cpp
+++ b/source/greentea_test_env.cpp
@@ -20,6 +20,10 @@
 #include <cstring>
 #include "greentea-client/test_env.h"
 
+#define str(s) #s
+#define xstr(s) str(s)
+#define GIT_VERSION_STRING xstr(GIT_VERSION)
+
 /**
  *   Generic test suite transport protocol keys
  */
@@ -476,7 +480,7 @@ static void greentea_notify_completion(const int result)
  */
 static void greentea_notify_version()
 {
-    greentea_send_kv(GREENTEA_TEST_ENV_HOST_TEST_VERSION, "1.3.0");
+    greentea_send_kv(GREENTEA_TEST_ENV_HOST_TEST_VERSION, GIT_VERSION_STRING);
 }
 
 /**


### PR DESCRIPTION
Attempt to determine a version automatically using git. Fallback to
v0.0.0 if the version can't be determined (e.g. due to git error, or if
the library is not from a git repo).

This makes it easier to tag-to-release as we don't have to edit a file
at the same time we make a tag: no repository contents need change when
making a release.