### PR TITLE
Add unit tests and code coverage

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -41,3 +41,17 @@ jobs:
       run: |
         cmake -S tests/integration/imported-targets -B __downstream_build -GNinja
         cmake --build __downstream_build
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install CMake and Ninja
+      uses: lukka/get-cmake@latest
+
+    - name: Run Unit Tests
+      run: |
+        cmake -S . -B __build -GNinja
+        cmake --build __build
+        cmake --build __build --target test

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,9 +13,8 @@ jobs:
 
     - name: Run astyle
       run: |
-          git diff --name-only --diff-filter=d FETCH_HEAD..HEAD \
-            | ( grep '.*\.\(c\|cpp\|h\|hpp\)$' || true ) \
-            | while read file; do astyle -n --options=.astylerc "${file}"; done
+          find . -type f \( -name "*.cpp" -or -name "*.c" -or -name "*.h" -or -name "*.hpp" \) \
+            -exec astyle -n --options=.astylerc {} \;
           git diff --exit-code --diff-filter=d --color
 
   test-app:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -52,6 +52,12 @@ jobs:
 
     - name: Run Unit Tests
       run: |
-        cmake -S . -B __build -GNinja
+        cmake -S . -B __build -GNinja -DENABLE_COVERAGE=ON
         cmake --build __build
         cmake --build __build --target test
+
+    - name: Upload Coverage to codecov.io
+      uses: codecov/codecov-action@v1
+      with:
+        verbose: true
+        fail_ci_if_error: true

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -26,19 +26,14 @@ jobs:
     - name: Install CMake and Ninja
       uses: lukka/get-cmake@latest
 
-    - name: Build stdio Example Application
+    - name: Build Example Applications
       run: |
         cmake -S . -B __build -GNinja
         cmake --build __build
 
-    - name: Build Custom IO Example Application
-      run: |
-        cmake -S . -B __build -GNinja -DGREENTEA_CLIENT_STDIO=OFF
-        cmake --build __build
-
     - name: Install greentea-client
       run: |
-        cmake -S . -B __build -GNinja -DGREENTEA_CLIENT_STDIO=ON
+        cmake -S . -B __build -GNinja
         cmake --build __build
         sudo cmake --install __build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,3 +92,11 @@ if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME) AND BUILD_EXAMPLES)
     add_subdirectory(examples/custom_io)
     add_subdirectory(examples/pty)
 endif()
+
+# Tests
+
+include(CTest)
+
+if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME) AND BUILD_TESTING)
+    add_subdirectory(tests/unit)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,5 +98,5 @@ endif()
 include(CTest)
 
 if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME) AND BUILD_TESTING)
-    add_subdirectory(tests/unit)
+    add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,28 +11,36 @@ project(greentea
 
 include(GNUInstallDirs)
 
-add_library(client)
+add_library(client_userio
+    source/greentea_test_env.cpp
+)
+target_include_directories(client_userio
+    PUBLIC
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+
+add_library(client
+    source/greentea_test_env.cpp
+    source/greentea_test_io.c
+)
 target_include_directories(client
     PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-target_sources(client
-    PRIVATE
-        source/greentea_test_env.cpp
-)
-
-# Consumers using add_subdirectory should link to this target. This alias keeps
-# the naming consistent between superprojects that include greentea-client in
-# the source tree and projects that use the installed greentea-client library
-# using find_package.
+# Consumers using add_subdirectory should link to these targets. The aliases
+# keep the naming consistent between superprojects that include greentea-client
+# in the source tree and projects that use the installed greentea-client
+# library using find_package.
+add_library(greentea::client_userio ALIAS client_userio)
 add_library(greentea::client ALIAS client)
 
 # Exported targets
 
 install(
-    TARGETS client
+    TARGETS client client_userio
     EXPORT greentea-client-targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -75,26 +83,12 @@ export(
     NAMESPACE greentea::
 )
 
-# Default IO
-
-SET(GREENTEA_CLIENT_STDIO ON CACHE BOOL "Use stdio for IO")
-
-if(GREENTEA_CLIENT_STDIO)
-    target_sources(client
-        PRIVATE
-            source/greentea_test_io.c
-    )
-endif()
-
 # Example applications
 
 set(BUILD_EXAMPLES ON CACHE BOOL "Enable building the examples")
 
 if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME) AND BUILD_EXAMPLES)
-    if(GREENTEA_CLIENT_STDIO)
-        add_subdirectory(examples/stdio)
-    else()
-        add_subdirectory(examples/custom_io)
-        add_subdirectory(examples/pty)
-    endif()
+    add_subdirectory(examples/stdio)
+    add_subdirectory(examples/custom_io)
+    add_subdirectory(examples/pty)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 
 project(greentea
     VERSION 0.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ export(
 
 # Example applications
 
-set(BUILD_EXAMPLES ON CACHE BOOL "Enable building the examples")
+option(BUILD_EXAMPLES "Enable building the examples" ON)
 
 if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME) AND BUILD_EXAMPLES)
     add_subdirectory(examples/stdio)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  ignore:
+    - '*/tests/'
+    - '*/examples/'
+    - '*/__build/'

--- a/examples/custom_io/CMakeLists.txt
+++ b/examples/custom_io/CMakeLists.txt
@@ -4,5 +4,5 @@
 add_executable(greentea-client-example-custom-io main.cpp)
 
 target_link_libraries(greentea-client-example-custom-io
-        greentea::client
+        greentea::client_userio
 )

--- a/source/greentea_test_io.c
+++ b/source/greentea_test_io.c
@@ -18,12 +18,14 @@
 #include "greentea-client/test_io.h"
 #include <stdio.h>
 
-int greentea_getc() {
+int greentea_getc()
+{
     return getchar();
 }
 
 
-void greentea_putc(int c) {
+void greentea_putc(int c)
+{
     putchar(c);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(doubles)
+add_subdirectory(unit)

--- a/tests/doubles/CMakeLists.txt
+++ b/tests/doubles/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(fake-console-io ./fake_console_io.cpp)
+target_compile_features(fake-console-io PUBLIC cxx_std_14)
+target_include_directories(fake-console-io PUBLIC .)
+target_link_libraries(fake-console-io PRIVATE greentea::client_userio)

--- a/tests/doubles/fake_console_io.cpp
+++ b/tests/doubles/fake_console_io.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <algorithm>
+
+#include "greentea-client/test_io.h"
+#include "fake_console_io.h"
+
+static std::string _stdout;
+static std::string _stdin;
+
+Console::Console()
+{
+}
+
+std::string Console::get_stdout() const
+{
+    return _stdout;
+}
+
+void Console::set_stdin(const std::string &str)
+{
+    _stdin.append(str);
+    std::reverse(_stdin.begin(), _stdin.end());
+}
+
+Console::~Console()
+{
+    _stdout = {};
+    _stdin = {};
+}
+
+int greentea_getc()
+{
+    int out = EOF;
+    if (!_stdin.empty()) {
+        out = _stdin.back();
+        _stdin.pop_back();
+    }
+    return out;
+}
+
+void greentea_putc(int c)
+{
+    _stdout.push_back(c);
+}
+
+void greentea_write_string(const char *str)
+{
+    _stdout.append(str);
+}

--- a/tests/doubles/fake_console_io.h
+++ b/tests/doubles/fake_console_io.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _FAKE_CONSOLE_IO
+#define _FAKE_CONSOLE_IO
+
+#include <string>
+
+struct Console {
+    Console();
+    ~Console();
+
+    void set_stdin(const std::string &);
+    std::string get_stdout() const;
+};
+
+#endif // _FAKE_CONSOLE_IO

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -15,3 +15,18 @@ FetchContent_MakeAvailable(googletest)
 add_executable(greentea-tests test_kv_protocol.cpp)
 target_link_libraries(greentea-tests PRIVATE greentea::client gtest_main)
 gtest_discover_tests(greentea-tests DISCOVERY_MODE PRE_TEST)
+
+# Coverage
+
+option(ENABLE_COVERAGE "Enable code coverage" OFF)
+
+if(ENABLE_COVERAGE)
+    target_compile_options(greentea-tests
+        PUBLIC
+            --coverage -O0 -g
+    )
+    target_link_options(greentea-tests
+        PUBLIC
+            --coverage
+    )
+endif()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -13,7 +13,8 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(googletest)
 
 add_executable(greentea-tests test_kv_protocol.cpp)
-target_link_libraries(greentea-tests PRIVATE greentea::client gtest_main)
+target_compile_features(greentea-tests PUBLIC cxx_std_14)
+target_link_libraries(greentea-tests PUBLIC greentea::client_userio fake-console-io gtest_main)
 gtest_discover_tests(greentea-tests DISCOVERY_MODE PRE_TEST)
 
 # Coverage

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+include(FetchContent)
+include(GoogleTest)
+
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        master
+)
+
+FetchContent_MakeAvailable(googletest)
+
+add_executable(greentea-tests test_kv_protocol.cpp)
+target_link_libraries(greentea-tests PRIVATE greentea::client gtest_main)
+gtest_discover_tests(greentea-tests DISCOVERY_MODE PRE_TEST)

--- a/tests/unit/test_kv_protocol.cpp
+++ b/tests/unit/test_kv_protocol.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "greentea-client/test_env.h"

--- a/tests/unit/test_kv_protocol.cpp
+++ b/tests/unit/test_kv_protocol.cpp
@@ -13,6 +13,85 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <string>
 
 #include <gtest/gtest.h>
+
+#include "fake_console_io.h"
 #include "greentea-client/test_env.h"
+
+class KiViProtocolTest: public testing::Test {
+public:
+    Console fake_console;
+
+protected:
+    KiViProtocolTest() {}
+    virtual ~KiViProtocolTest() {}
+    virtual void TearDown() override
+    {
+        fake_console = {};
+    }
+};
+
+TEST_F(KiViProtocolTest, SendStringValue)
+{
+    const std::string key = "hello";
+    const std::string value = "99";
+    const std::string output = "{{" + key + ";" + value + "}}\r\n";
+    greentea_send_kv(key.c_str(), value.c_str());
+
+    const std::string console = fake_console.get_stdout();
+    ASSERT_EQ(console, output);
+}
+
+TEST_F(KiViProtocolTest, SendIntValue)
+{
+    const std::string key = "hello";
+    const int value = 99;
+    const std::string output = "{{" + key + ";" + std::to_string(value) + "}}\r\n";
+
+    greentea_send_kv(key.c_str(), value);
+
+    const std::string console = fake_console.get_stdout();
+    ASSERT_EQ(console, output);
+}
+
+TEST_F(KiViProtocolTest, SendIntPassFailCount)
+{
+    const std::string key = "hello";
+    const int passes = 99;
+    const int failures = 19;
+    const std::string output = "{{" + key + ";" + std::to_string(passes) + ";" + std::to_string(failures) + "}}\r\n";
+
+    greentea_send_kv(key.c_str(), passes, failures);
+
+    const std::string console = fake_console.get_stdout();
+    ASSERT_EQ(console, output);
+}
+
+TEST_F(KiViProtocolTest, SendStringValueAndResultCount)
+{
+    const std::string key = "hello";
+    const std::string value = "hey";
+    const int result = 99;
+    const std::string output = "{{" + key + ";" + value + ";" + std::to_string(result) + "}}\r\n";
+
+    greentea_send_kv(key.c_str(), value.c_str(), result);
+
+    const std::string console = fake_console.get_stdout();
+    ASSERT_EQ(console, output);
+}
+
+TEST_F(KiViProtocolTest, SendStringValueAndPassFailCount)
+{
+    const std::string key = "hello";
+    const std::string value = "hey";
+    const int passes = 1;
+    const int failures = 99;
+    const std::string output = "{{" + key + ";" + value + ";" + std::to_string(passes) + ";" + std::to_string(failures) + "}}\r\n";
+
+    greentea_send_kv(key.c_str(), value.c_str(), passes, failures);
+
+    const std::string console = fake_console.get_stdout();
+    ASSERT_EQ(console, output);
+}


### PR DESCRIPTION
This PR makes the following changes:

Adds unit tests using GoogleTest. GoogleTest will be fetched automatically by CMake at 
configuration-time.
To stop CMake from trying to fetch GoogleTest pass the `-DBUILD_TESTING=OFF`
option to CMake when configuring the build system.

Adds an ENABLE_COVERAGE cmake option, when this is ON then the coverage flags
are added to the compiler and linker options. A job is added to the github CI workflow 
to run the unit tests and upload results to codecov.

Reworks the cmake targets to remove the option for disabling stdio. 
Instead we now have a "client_userio" target, so consumers can just link to the target
they need depending on their IO setup. This is easier for users than trying to forward 
options to greentea-client at configure time to disable stdio, which may not even be 
feasible if the user isn't building greentea-client from source.