### PR TITLE
Fix codecov uploads

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -45,9 +45,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Install CMake and Ninja
       uses: lukka/get-cmake@latest
+
+    - name: Install lcov
+      run: sudo apt-get install -y lcov
 
     - name: Run Unit Tests
       run: |
@@ -55,8 +60,11 @@ jobs:
         cmake --build __build
         cmake --build __build --target test
 
-    - name: Upload Coverage to codecov.io
-      uses: codecov/codecov-action@v1
-      with:
-        verbose: true
-        fail_ci_if_error: true
+    - name: Create Coverage Report
+      run: |
+          lcov --directory . --capture --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' '*/tests/*' '*/examples/*' '*/_deps/*' --output-file coverage.info
+          lcov --list coverage.info
+
+    - name: Upload Coverage Report to codecov.io
+      run: bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov upload failed"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,0 @@
-coverage:
-  ignore:
-    - '*/tests/'
-    - '*/examples/'
-    - '*/__build/'

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -22,11 +22,11 @@ gtest_discover_tests(greentea-tests DISCOVERY_MODE PRE_TEST)
 option(ENABLE_COVERAGE "Enable code coverage" OFF)
 
 if(ENABLE_COVERAGE)
-    target_compile_options(greentea-tests
+    target_compile_options(client_userio
         PUBLIC
             --coverage -O0 -g
     )
-    target_link_options(greentea-tests
+    target_link_options(client_userio
         PUBLIC
             --coverage
     )


### PR DESCRIPTION
Coverage uploads to codecov.io weren't working, because the codecov github action didn't create the reports in the correct format for codecov to process out of the box. The interface for the action is rather limited in terms of configuration options. So, now we invoke `lcov` ourselves to create the coverage report and upload directly using the bash uploader.

This PR makes the following changes:
* Run `lcov` in the CI and upload the report using the bash uploader
* Pass --coverage flags directly to greentea::client to ensure correct gcno files are generated
* Remove codecov.yml as we don't need any custom configuration at the moment
