### PR TITLE
cmake: Only include CTest if we're the current project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,9 @@ endif()
 
 # Tests
 
-include(CTest)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    include(CTest)
+endif()
 
 if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME) AND BUILD_TESTING)
     add_subdirectory(tests)


### PR DESCRIPTION
Avoids enabling testing for consumers who don't want to enable testing
when depending on greentea-client.